### PR TITLE
Bugfix/seedblog

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -1,6 +1,22 @@
 const User = require('./User');
 const Blog = require('./Blog')
 
-// User.hasMany
+//establish database relationships: see bootcamp module 13 on ORM for more examples/explanation
+//blog has one user, if user is deleted this cascades to their blogs and deletes them too, user id is foreign key referencing id column in user table
+Blog.hasOne(User, {
+    foreignKey: 'user_id',
+    onDelete: 'CASCADE',
+  });
+  
+  Blog.belongsTo(User, {
+    foreignKey: 'user_id',
+  });
+  
+  // Define a user as having many blogs, creates a foreign key in the `blog` table
+  User.hasMany(Blog, {
+    foreignKey: 'user_id',
+    onDelete: 'CASCADE',
+  });
+  
 
 module.exports = { User, Blog };

--- a/seeds/seed.js
+++ b/seeds/seed.js
@@ -8,33 +8,24 @@ const userData = require('./userData.json');
  const blogData = require('./blogData.json');
 
  //function to seed the example users into the database
-const seedUser = async () => {
+const seedDatabase = async () => {
   //syncs the Sequelize models with the database
-  //force:true means that when the models and datbase are synchronized, all tables wll be dropped and recreated, resting the DB schema
+  //force:true means that when the models and datbase are synchronized, all tables wll be dropped and recreated, reseting the DB schema
  await sequelize.sync({ force: true });
 //bulkCreate puts multiple items into the User table at once, userData is an array of data getting inserted into the dtabase
 //individual hooks: true means if the model uses hooks they will be executed on each instance of the model, return data inserted
+//seed the users first to not violate the foreign key constraints of the blog model that uses the user id as a foreign key, then seed the blogs
   await User.bulkCreate(userData, {
     individualHooks: true,
     returning: true,
   });
 
-  //exit node.js process, success status code is (0)
-  process.exit(0);
-};
-
-//call the function to seed users
-seedUser();
-
-//function to seed the example blogs into the database
-const seedBlog = async () => {
-  //syncs the Sequelize models with the database
-  await sequelize.sync({ force: true });
-//creates multiple instances of Blog model as outlined in blogData seeds file
+  //creates multiple instances of Blog model as outlined in blogData seeds file
   await Blog.bulkCreate(blogData);
+
   //exit node.js process, success status code is (0)
   process.exit(0);
 };
 
-//calls seedBlog function
-seedBlog();
+//call the function to seed the database
+seedDatabase();

--- a/seeds/seed.js
+++ b/seeds/seed.js
@@ -11,7 +11,7 @@ const userData = require('./userData.json');
 const seedUser = async () => {
   //syncs the Sequelize models with the database
   //force:true means that when the models and datbase are synchronized, all tables wll be dropped and recreated, resting the DB schema
- // await sequelize.sync({ force: true });
+ await sequelize.sync({ force: true });
 //bulkCreate puts multiple items into the User table at once, userData is an array of data getting inserted into the dtabase
 //individual hooks: true means if the model uses hooks they will be executed on each instance of the model, return data inserted
   await User.bulkCreate(userData, {
@@ -28,6 +28,8 @@ seedUser();
 
 //function to seed the example blogs into the database
 const seedBlog = async () => {
+  //syncs the Sequelize models with the database
+  await sequelize.sync({ force: true });
 //creates multiple instances of Blog model as outlined in blogData seeds file
   await Blog.bulkCreate(blogData);
   //exit node.js process, success status code is (0)

--- a/seeds/userData.json
+++ b/seeds/userData.json
@@ -1,6 +1,6 @@
 [
     {
-      "id": "1",
+        "id": "1",
         "name": "Victoria",
         "email": "victoria@gmail.com",
         "password": "password12345"


### PR DESCRIPTION
-added missing sequelize.sync statement to seed function to synchronize the database with the models
-consolidated the seed functions into one function for efficiency and to remove error that ` await sequelize.sync({ force: true });` was causing by appearing twice and deleting the user table after it had been seeded/preventing blog table from being seeded
-added data relationships to models index.js